### PR TITLE
Fix Maven deployment configuration

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Le joueur démarre avec un nombre limité de munitions et de santé. Son but est
 ## Installation
 
 1. **Prérequis** :
-    - [Java JDK 11+](https://www.oracle.com/java/technologies/javase-jdk11-downloads.html)
+    - [Java JDK 17+](https://adoptium.net/)
+    - [Maven](https://maven.apache.org/)
     - [JavaFX](https://openjfx.io/)
 
 2. **Cloner le dépôt** :
@@ -61,10 +62,14 @@ Le joueur démarre avec un nombre limité de munitions et de santé. Son but est
    ```
 
 3. **Compiler et Exécuter** :
-   Utilisez votre IDE Java préféré (comme IntelliJ IDEA ou Eclipse) ou compilez en ligne de commande :
+   Utilisez votre IDE Java préféré (comme IntelliJ IDEA ou Eclipse) ou lancez directement via Maven :
    ```bash
-   javac -d bin -sourcepath src src/main/java/com/testgame/testgame/GameApp.java
-   java -cp bin com.testgame.testgame.GameApp
+   mvn javafx:run
+   ```
+   Pour générer un JAR exécutable :
+   ```bash
+   mvn package
+   java -jar target/InfiniteCubeFrenzy-1.0-SNAPSHOT-shaded.jar
    ```
 
 ## Utilisation
@@ -73,7 +78,11 @@ Le joueur démarre avec un nombre limité de munitions et de santé. Son but est
 - **Commandes** :
     - **Déplacement** : Utilisez les flèches directionnelles.
     - **Attaque Normale** : Appuyez sur la barre d'espace pour tirer un projectile.
-    - **Collecte de Bonus** : Passez sur un pack de munitions ou une vie supplémentaire pour le collecter.
+- **Collecte de Bonus** : Passez sur un pack de munitions ou une vie supplémentaire pour le collecter.
+
+## Déploiement
+
+Le projet est configuré pour être publié sur **GitHub Packages**. Une fois le code prêt, créez une nouvelle release depuis l'onglet *Releases* de GitHub. Le workflow `Maven Package` se déclenchera automatiquement, compilera le jeu et publiera le JAR dans le dépôt Maven du projet.
 
 ## Captures d'écran
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,4 +107,11 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <url>https://maven.pkg.github.com/Oriloo/Infinite-Cube-Frenzy</url>
+        </repository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
## Summary
- update workflow to use JDK 17
- publish artifacts to GitHub Packages via distributionManagement
- clarify build instructions and add deployment guide in README

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c711be20832cbbb82b9a7c6e3ed5